### PR TITLE
Add vscode gdb launch script and gdb freertos_task_backtrace

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,26 @@
+define freertos_task_backtrace
+
+    # Register stored by CPU when exception
+    set $sp=&((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[17]
+    set $xpsr=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[16]
+    set $pc=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[15]
+    set $lr=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[14]
+    set $r12=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[13]
+    set $r3=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[12]
+    set $r2=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[11]
+    set $r1=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[10]
+    set $r0=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[9]
+
+    # Registers stored when context switch
+    set $lr=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[8]
+    set $r11=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[7]
+    set $r10=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[6]
+    set $r9=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[5]
+    set $r8=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[4]
+    set $r7=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[3]
+    set $r6=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[2]
+    set $r5=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[1]
+    set $r4=((uint32_t*)((TCB_t*)($arg0))->pxTopOfStack)[0]
+
+    bt
+end

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "FreeRTOS crash debug",
+        "type": "cppdbg",
+        "request": "launch",
+        "program": "${workspaceRoot}/ST_Code/Debug/FreeRTOS_Plus_TCP_Demo.elf",
+        "miDebuggerServerAddress" : " | CrashDebug --elf ./ST_Code/Debug/FreeRTOS_Plus_TCP_Demo.elf --dump ./GeneratedCoreDump.txt",
+        "stopAtEntry": false,
+        "cwd": "${workspaceRoot}",
+        "environment": [],
+        "externalConsole": false,
+        "windows": {
+            "MIMode": "gdb",
+            "setupCommands": [
+              {
+                "description": "Enable pretty-printing for gdb",
+                "text": "-enable-pretty-printing",
+                "ignoreFailures": true
+              },
+              {
+                "description": "Enable cortex-M7 FreeRTOS task backtrace",
+                "text": "source ${workspaceFolder}/.gdbinit",
+                "ignoreFailures": true
+              }
+            ],
+            "miDebuggerPath": "arm-none-eabi-gdb.exe",
+          }
+        }
+    ]
+}
+
+


### PR DESCRIPTION
Assuming the host PC already has the following tool in path
* vscode : https://code.visualstudio.com/
* vscode c++ extension : https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools
* CrashDebug : https://github.com/adamgreen/CrashDebug
* arm-none-eabi-gdb : https://developer.arm.com/downloads/-/gnu-rm

Option vscode extension
* RTOS view ( optional ) : https://marketplace.visualstudio.com/items?itemName=mcu-debug.rtos-views

#### In this PR:
* Add vscode extension to launch debugger session with crash dump.
The crashdump file should be placed at root folder with the name.
> ./GeneratedCoreDump.txt

* Add GDB function to print freertos task backtrace
Usage: in DEBUG CONSOLE tab "-exec freertos_task_backtrace \<address of TCB_t\>"
```
-exec freertos_task_backtrace xIdleTaskHandles[ 0 ]
-exec freertos_task_backtrace xTimerTAskHandle
-exec freertos_task_backtrace 0x20009898 ( some task handle )
```